### PR TITLE
Added secure device storage of masterkey

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,7 +13,10 @@
       "backgroundColor": "#ffffff"
     },
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "config": {
+        "usesNonExemptEncryption": false
+      }
     },
     "android": {
       "adaptiveIcon": {
@@ -27,7 +30,13 @@
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": [
-      "expo-router"
+      "expo-router",
+      [
+        "expo-secure-store",
+        {
+          "faceIDPermission": "Allow $(PRODUCT_NAME) to access your Face ID biometric data."
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true

--- a/app/auth/sign-in.tsx
+++ b/app/auth/sign-in.tsx
@@ -87,7 +87,7 @@ export default function SignInScreen() {
         </Text>
       </TouchableOpacity>
 
-      <TouchableOpacity onPress={() => router.replace("/sign-up")}>
+      <TouchableOpacity onPress={() => router.replace("auth/sign-up")}>
         <Text style={[styles.footerText, { color: Colors[colorScheme].text }]}>
           Don't have an account? Sign Up
         </Text>

--- a/app/auth/sign-up.tsx
+++ b/app/auth/sign-up.tsx
@@ -14,6 +14,7 @@ import { Colors } from "@/constants/Colors";
 import { useRouter } from "expo-router";
 import { doc, setDoc } from "firebase/firestore";
 import { generateSecretKey } from "@/algorithms/encryptPassword";
+import * as SecureStore from "expo-secure-store";
 
 export default function SignUpScreen() {
   const [email, setEmail] = useState("");
@@ -41,9 +42,16 @@ export default function SignUpScreen() {
         createdAt: new Date(),
       });
 
+      await SecureStore.setItemAsync("userId", userId, {
+        keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+      });
+      await SecureStore.setItemAsync("masterKey", masterKey, {
+        keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+      });
+
       Alert.alert(
         "Success",
-        "User created successfully and master key generated!",
+        "User created successfully and master key securely stored!"
       );
       router.replace("/home/(tabs)");
     } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,11 @@
         "expo": "~51.0.28",
         "expo-constants": "~16.0.2",
         "expo-crypto": "~13.0.2",
+        "expo-file-system": "~17.0.1",
         "expo-font": "~12.0.9",
         "expo-linking": "~6.3.1",
         "expo-router": "~3.5.23",
+        "expo-secure-store": "~13.0.2",
         "expo-splash-screen": "~0.27.5",
         "expo-status-bar": "~1.12.1",
         "expo-system-ui": "~3.0.7",
@@ -11489,6 +11491,14 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-13.0.2.tgz",
+      "integrity": "sha512-3QYgoneo8p8yeeBPBiAfokNNc2xq6+n8+Ob4fAlErEcf4H7Y72LH+K/dx0nQyWau2ZKZUXBxyyfuHFyVKrEVLg==",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-splash-screen": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "3.31.1",
-    "react-native-web": "~0.19.10"
+    "react-native-web": "~0.19.10",
+    "expo-file-system": "~17.0.1",
+    "expo-secure-store": "~13.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/utils/retrieveUserData.ts
+++ b/utils/retrieveUserData.ts
@@ -1,0 +1,12 @@
+import * as SecureStore from "expo-secure-store";
+
+export const retrieveUserData = async () => {
+  const userId = await SecureStore.getItemAsync("userId");
+  const masterKey = await SecureStore.getItemAsync("masterKey");
+
+  if (userId && masterKey) {
+    return { userId, masterKey };
+  } else {
+    console.log("No user data found.");
+  }
+};


### PR DESCRIPTION
This PR adds file system secure storage without the use of FaceID ( not available in Expo Go) for masterKeys, so the key is securely stored in users devices as well, but it is not accessible if the filesystem is exposed
